### PR TITLE
[0.2.1] add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,36 @@
 
 Github Action that rotates through a list of reviewers for reviewing a PR
 
-_TODO: Add good docs and the like_
+## Inputs
+
+### `reviewers`
+**REQUIRED** A whitespace separated list of reviewers and/or teams for reviewing
+### `rotation`
+The frequency of rotation (e.g. "2 days", "4 weeks", "3 months", "1 year"). Default is `1 week`.
+### `fetch-team-users`
+Boolean if the rotation list should expand teams to individual members from teams given
+### `token`
+A github token to access team members if `fetch-team-users` is true
+
+
+## Outputs:
+
+### `reviewer`
+The assigned reviewer or team
+### `team`
+The team the reviewer belongs to (if applicable)
+### `calendar`
+The immediate review schedule. Example: _team1 will review from Today until 3/25/2021. team2 will review from 3/26/2021 until 4/16/2021._
+
+
+## Example usage
+
+```yml
+- uses: kyle-west/action-review-rotation@v0.2
+  id: getRev
+  with:
+    reviewers: kyle-west digital-taco/admin digital-taco/qa
+    rotation: 4 Weeks
+- run: echo "reviewer is ${{ steps.getRev.outputs.reviewer }}"
+- run: echo "calendar is ${{ steps.getRev.outputs.calendar }}"
+```

--- a/action.yml
+++ b/action.yml
@@ -2,25 +2,25 @@ name: 'Review'
 description: 'Rotate through a list of reviewers for reviewing a PR'
 inputs:
   reviewers:
-    description: 'list of reviewers and/or teams for reviewing'
+    description: 'A whitespace separated list of reviewers and/or teams for reviewing'
     required: true
   rotation:
-    description: 'frequency of rotation (e.g. "2 days", "4 weeks", "3 months", "1 year")'
+    description: 'The frequency of rotation (e.g. "2 days", "4 weeks", "3 months", "1 year")'
     required: false
     default: '1 week'
   fetch-team-users:
-    description: 'should the rotation list fetch out members from teams given'
+    description: 'Boolean if the rotation list should expand teams to individual members from teams given'
     required: false
   token:
-    description: 'github token to access team members'
+    description: 'A github token to access team members if fetch-team-users is true'
     required: false
 outputs:
   reviewer:
-    description: 'DRI for reviewing the PR'
+    description: 'The assigned reviewer or team'
   team:
-    description: 'The team responsible for reviewing the PR'
+    description: 'The team the reviewer belongs to (if applicable)'
   calendar:
-    description: 'The current and next schedule dates'
+    description: 'The immediate review schedule'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-review-rotation",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-review-rotation",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Rotate through a list of reviewers for reviewing a PR",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
# Review Rotation


Github Action that rotates through a list of reviewers for reviewing a PR	Github Action that rotates through a list of reviewers for reviewing a PR


_TODO: Add good docs and the like_	## Inputs

### `reviewers`
**REQUIRED** A whitespace separated list of reviewers and/or teams for reviewing
### `rotation`
The frequency of rotation (e.g. "2 days", "4 weeks", "3 months", "1 year"). Default is `1 week`.
### `fetch-team-users`
Boolean if the rotation list should expand teams to individual members from teams given
### `token`
A github token to access team members if `fetch-team-users` is true


## Outputs:

### `reviewer`
The assigned reviewer or team
### `team`
The team the reviewer belongs to (if applicable)
### `calendar`
The immediate review schedule. Example: _team1 will review from Today until 3/25/2021. team2 will review from 3/26/2021 until 4/16/2021._


## Example usage

```yml
- uses: kyle-west/action-review-rotation@v0.2
  id: getRev
  with:
    reviewers: kyle-west digital-taco/admin digital-taco/qa
    rotation: 4 Weeks
- run: echo "reviewer is ${{ steps.getRev.outputs.reviewer }}"
- run: echo "calendar is ${{ steps.getRev.outputs.calendar }}"
```